### PR TITLE
Fix mistake in length description of SYNC BYTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Frame format is:
 The Frame format is:
 
     +--------------------+-----------------+--------------------------+-- - - --+--------------+
-    | SYNC BYTE [2 Byte] | LENGTH [2 Byte] | INVERTED LENGTH [2 Byte] | PAYLOAD | CRC [2 Byte] |
+    | SYNC BYTE [1 Byte] | LENGTH [2 Byte] | INVERTED LENGTH [2 Byte] | PAYLOAD | CRC [2 Byte] |
     +--------------------+-----------------+--------------------------+-- - - --+--------------+
 
   - INVERTED LENGTH: Bit inverted length field.


### PR DESCRIPTION
The SYNC BYTE has a length of one Byte not two.